### PR TITLE
fix: fix CORS OPTIONS request for middleware api

### DIFF
--- a/src/middleware/index.ts
+++ b/src/middleware/index.ts
@@ -184,16 +184,17 @@ export const middleware = async (req, res) => {
 	}
 
 	const config = req.body || req.query
-	const commerceAPI = await getCommerceAPI(config)
 	switch (req.method.toLowerCase()) {
 	case 'get':
 	case 'post':
+	{
+		const commerceAPI = await getCommerceAPI(config)
 		try {
 			return res.status(200).json(createMiddlewareResponse(config, await commerceAPI[config.operation](config)))
 		} catch (e) {
 			return res.status(200).json({error: toApiError(e)})
 		}
-
+	}
 	case 'options':
 		return res.status(200).send()
 


### PR DESCRIPTION
There is an issue with the existing middleware API code where OPTIONS requests made from CORS access would attempt to get the commerce API, but no configuration parameters were passed.

This change ignores the configuration parameters (and doesn't get any commerce API) when doing an OPTIONS request.