### PR TITLE
fix(commercetools): respect language for category list, select first available language

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ Using the `config` object for one of the commerce vendors, you can get the Comme
 const commerceApi = await getCommerceAPI(config)
 ```
 
+(NOTE: You should get a new Commerce API whenever you want to use different credentials or a different locale/language)
+
 From there you can use any of the commerce methods:
 
 ```typescript

--- a/docs/dev/host.md
+++ b/docs/dev/host.md
@@ -3,7 +3,7 @@
 To host your own version, simply fork the repo and `npm install` your own fork.
 
 ```
-npm i @yourgithub/dc-integration-middleware
+npm i github:<your github>/dc-integration-middleware
 ```
 
 That's really it.

--- a/docs/dev/import.md
+++ b/docs/dev/import.md
@@ -5,8 +5,10 @@ To use the integration in an existing project, you can refer to how we're using 
 ## Import the npm package
 
 ```
-$ npm i @amplience/dc-integration-middleware
+$ npm i github:amplience/dc-integration-middleware
 ```
+
+You can specify a specific version with #.
 
 ## Export middleware and init
 

--- a/docs/vendor/commerce/commercetools.md
+++ b/docs/vendor/commerce/commercetools.md
@@ -40,3 +40,5 @@ Next you can select the required scopes:
 You can then access the credentials (one time) with all the required properties:
 
 ![](../../media/commercetoolsC.png)
+
+> Note: This integrations uses the [Product Projection Search API HTTP API](https://docs.commercetools.com/api/projects/products-search) from CommerceTools. Please follow steps in their documentation to ensure that this is enabled (ie indexing enabled)

--- a/docs/vendor/commerce/commercetools.md
+++ b/docs/vendor/commerce/commercetools.md
@@ -14,6 +14,7 @@ See the [CORS](../../../README.md#cors-support-table) / [Server](../../../README
     "vendor": "commercetools",
     "codec_params": {
         "project": "<ct project key>",
+        "language": "<language to prioritise>",
         "client_id": "<ct client id>",
         "client_secret": "<ct client secret>",
         "auth_url": "<ct auth url",

--- a/docs/vendor/commerce/commercetools.md
+++ b/docs/vendor/commerce/commercetools.md
@@ -41,4 +41,4 @@ You can then access the credentials (one time) with all the required properties:
 
 ![](../../media/commercetoolsC.png)
 
-> Note: This integrations uses the [Product Projection Search API HTTP API](https://docs.commercetools.com/api/projects/products-search) from CommerceTools. Please follow steps in their documentation to ensure that this is enabled (ie indexing enabled)
+> Note: This integration uses the [Product Projection Search API HTTP API](https://docs.commercetools.com/api/projects/products-search) from CommerceTools. Please follow steps in their documentation to ensure that this is enabled (ie indexing enabled)

--- a/src/codec/codecs/commerce/commercetools/commercetools.test.ts
+++ b/src/codec/codecs/commerce/commercetools/commercetools.test.ts
@@ -3,7 +3,7 @@ import axios from 'axios'
 import { CommerceCodec } from '../../core'
 import CommercetoolsCodecType, { CommercetoolsCodec } from '.'
 import { ctoolsCategories, ctoolsCustomerGroups, ctoolsProduct, ctoolsSearchResult } from './test/responses'
-import { exampleCustomerGroups, exampleCategoryTree, exampleProduct } from './test/results'
+import { exampleCustomerGroups, exampleCategoryTree, exampleCategoryTreeEs, exampleProduct } from './test/results'
 import { categoriesRequest, customerGroupsRequest, oauthRequest, searchRequest } from './test/requests'
 import { config } from './test/config'
 import { flattenConfig } from '../../../../common/util'
@@ -280,6 +280,20 @@ describe('commercetools integration', function() {
 		])
 
 		expect(categoryTree).toEqual(exampleCategoryTree)
+	})
+
+	test('getCategoryTree localized', async () => {
+		const codecLocalized = new CommercetoolsCodec({ ...flattenConfig(config), language: 'es' })
+		await codecLocalized.init(new CommercetoolsCodecType())
+
+		const categoryTree = await codecLocalized.getCategoryTree({})
+
+		expect(requests).toEqual([
+			oauthRequest,
+			categoriesRequest
+		])
+
+		expect(categoryTree).toEqual(exampleCategoryTreeEs)
 	})
 
 	test('getCustomerGroups', async () => {

--- a/src/codec/codecs/commerce/commercetools/commercetools.test.ts
+++ b/src/codec/codecs/commerce/commercetools/commercetools.test.ts
@@ -243,7 +243,7 @@ describe('commercetools integration', function() {
 	})
 
 	test('getCategory', async () => {
-		const category = await codec.getCategory({ slug: 'men' })
+		const category = await codec.getCategory({ slug: 'root-men' })
 
 		expect(requests).toEqual([
 			oauthRequest,
@@ -255,11 +255,19 @@ describe('commercetools integration', function() {
 		expect(category.products.length).toEqual(30)
 
 		expect(category).toEqual({
-			children: [],
+			children: [
+				{
+					children: [],
+					id: 'mens-accessories-id',
+					name: 'Men\'s Accessories',
+					products: [],
+					slug: 'mens-accessories',
+				}
+			],
 			products: Array.from({length: 30}).map((_, index) => exampleProduct('Hit' + index)),
 			id: 'men-id',
 			name: 'Men',
-			slug: 'men',
+			slug: 'root-men',
 		})
 	})
 

--- a/src/codec/codecs/commerce/commercetools/index.ts
+++ b/src/codec/codecs/commerce/commercetools/index.ts
@@ -74,7 +74,8 @@ export class CommercetoolsCodecType extends CommerceCodecType {
  * @param args Method arguments that contain the language
  */
 const localize = (localizable: Localizable, args: CommonArgs): string => {
-	return localizable[args.language] || localizable.en
+	//TODO: Remove hard coding en-US and make so that it works from installation params in extension (eComm Toolkit)
+	return localizable["en-US"] || localizable[args.language] || localizable.en
 }
 
 /**
@@ -203,8 +204,11 @@ export class CommercetoolsCodec extends CommerceCodec {
 	 */
 	async cacheCategoryTree(): Promise<void> {
 		const categories: CTCategory[] = (await paginate<CTCategory>(this.getPage(this.rest, '/categories'), 500)).result
+		const rootCats:string[] = categories
+			.filter(cat => cat.parent?.typeId !== "category")
+			.map(cat => localize(cat.slug, {}))
 		const mapped: Category[] = categories.map(cat => mapCategory(cat, categories, {}))
-		this.categoryTree = mapped.filter(cat => cats.includes(cat.slug))
+		this.categoryTree = mapped.filter(cat => rootCats.includes(cat.slug))
 	}
 
 	/**

--- a/src/codec/codecs/commerce/commercetools/index.ts
+++ b/src/codec/codecs/commerce/commercetools/index.ts
@@ -72,7 +72,7 @@ export class CommercetoolsCodecType extends CommerceCodecType {
  * @param args Method arguments that contain the language
  */
 const localize = (localizable: Localizable, args: CommonArgs): string => {
-	return localizable[args.language] ?? localizable.en ?? localizable[Object.keys(localizable)[0]]
+	return localizable[args.language] ?? localizable.en ?? localizable[Object.keys(localizable).sort()[0]]
 }
 
 /**

--- a/src/codec/codecs/commerce/commercetools/index.ts
+++ b/src/codec/codecs/commerce/commercetools/index.ts
@@ -19,8 +19,6 @@ import { getPageByQuery, paginate, paginateArgs } from '../../pagination'
 import { catchAxiosErrors } from '../../codec-error'
 import { getProductsArgError, mapIdentifiers } from '../../common'
 
-const cats = ['women', 'men', 'new', 'sale', 'accessories']
-
 /**
  * Commercetools Codec config properties
  */
@@ -74,8 +72,7 @@ export class CommercetoolsCodecType extends CommerceCodecType {
  * @param args Method arguments that contain the language
  */
 const localize = (localizable: Localizable, args: CommonArgs): string => {
-	//TODO: Remove hard coding en-US and make so that it works from installation params in extension (eComm Toolkit)
-	return localizable["en-US"] || localizable[args.language] || localizable.en
+	return localizable[args.language] ?? localizable.en ?? localizable[Object.keys(localizable)[0]]
 }
 
 /**
@@ -204,10 +201,12 @@ export class CommercetoolsCodec extends CommerceCodec {
 	 */
 	async cacheCategoryTree(): Promise<void> {
 		const categories: CTCategory[] = (await paginate<CTCategory>(this.getPage(this.rest, '/categories'), 500)).result
-		const rootCats:string[] = categories
-			.filter(cat => cat.parent?.typeId !== "category")
-			.map(cat => localize(cat.slug, {}))
-		const mapped: Category[] = categories.map(cat => mapCategory(cat, categories, {}))
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		const args = this.config as any
+		const rootCats: string[] = categories
+			.filter(cat => cat.parent?.typeId !== 'category')
+			.map(cat => localize(cat.slug, args))
+		const mapped: Category[] = categories.map(cat => mapCategory(cat, categories, args))
 		this.categoryTree = mapped.filter(cat => rootCats.includes(cat.slug))
 	}
 

--- a/src/codec/codecs/commerce/commercetools/test/responses.ts
+++ b/src/codec/codecs/commerce/commercetools/test/responses.ts
@@ -175,7 +175,7 @@ export const ctoolsCategories = {
 				it: 'Uomo',
 				en: 'Men\'s Accessories',
 				de: 'Männer',
-				es: 'Hombre',
+				es: 'Hombre Accessories',
 			},
 			slug: {
 				en: 'mens-accessories',

--- a/src/codec/codecs/commerce/commercetools/test/responses.ts
+++ b/src/codec/codecs/commerce/commercetools/test/responses.ts
@@ -122,8 +122,8 @@ export const ctoolsSearchResult = (
 export const ctoolsCategories = {
 	limit: 500,
 	offset: 0,
-	count: 1,
-	total: 1,
+	count: 2,
+	total: 2,
 	results: [
 		{
 			id: 'men-id',
@@ -139,7 +139,7 @@ export const ctoolsCategories = {
 				clientId: 'client',
 				isPlatformClient: false,
 			},
-			key: 'men',
+			key: 'root-men',
 			name: {
 				fr: 'Homme',
 				it: 'Uomo',
@@ -148,11 +148,48 @@ export const ctoolsCategories = {
 				es: 'Hombre',
 			},
 			slug: {
-				en: 'men',
+				en: 'root-men',
 			},
 			ancestors: [],
 			orderHint: '0.00001586885896788798824213',
 			externalId: '3',
+			assets: [],
+		},
+		{
+			id: 'mens-accessories-id',
+			version: 5,
+			lastMessageSequenceNumber: 3,
+			createdAt: '2020-04-14T17:38:16.788Z',
+			lastModifiedAt: '2021-11-17T18:04:29.834Z',
+			lastModifiedBy: {
+				clientId: 'client',
+				isPlatformClient: false,
+			},
+			createdBy: {
+				clientId: 'client',
+				isPlatformClient: false,
+			},
+			key: 'mens-accessories',
+			name: {
+				fr: 'Homme',
+				it: 'Uomo',
+				en: 'Men\'s Accessories',
+				de: 'Männer',
+				es: 'Hombre',
+			},
+			slug: {
+				en: 'mens-accessories',
+			},
+			parent: {
+				typeId: 'category',
+				id: 'men-id'
+			},
+			ancestors: [{
+				typeId: 'category',
+				id: 'men-id'
+			}],
+			orderHint: '0.00003',
+			externalId: '4',
 			assets: [],
 		},
 	],

--- a/src/codec/codecs/commerce/commercetools/test/results.ts
+++ b/src/codec/codecs/commerce/commercetools/test/results.ts
@@ -35,11 +35,19 @@ export const exampleCustomerGroups = [
 
 export const exampleCategoryTree = [
 	{
-		children: [],
+		children: [
+			{
+				children: [],
+				id: 'mens-accessories-id',
+				name: 'Men\'s Accessories',
+				products: [],
+				slug: 'mens-accessories',
+			}
+		],
 		id: 'men-id',
 		name: 'Men',
 		products: [],
-		slug: 'men',
+		slug: 'root-men',
 	}
 ]
 

--- a/src/codec/codecs/commerce/commercetools/test/results.ts
+++ b/src/codec/codecs/commerce/commercetools/test/results.ts
@@ -51,6 +51,24 @@ export const exampleCategoryTree = [
 	}
 ]
 
+export const exampleCategoryTreeEs = [
+	{
+		children: [
+			{
+				children: [],
+				id: 'mens-accessories-id',
+				name: 'Hombre Accessories',
+				products: [],
+				slug: 'mens-accessories',
+			}
+		],
+		id: 'men-id',
+		name: 'Hombre',
+		products: [],
+		slug: 'root-men',
+	}
+]
+
 export const exampleProduct = (id: string) => ({
 	categories: [],
 	id: id,

--- a/src/codec/index.ts
+++ b/src/codec/index.ts
@@ -8,7 +8,6 @@ codecs[CodecTypes.commerce] = []
 
 const hashExcludedConfig = [
 	'locale',
-	'language',
 	'country',
 	'currency',
 	'segment',


### PR DESCRIPTION
- Now identifies root categories properly rather than with a hardcoded array
- CacheCategoryTree now uses the initial config to select the language used for categories
  - If the language is missing or invalid, it will now return `en` or the first available language.
  - Middleware now includes language in the cache key, so requests with a different language will create a different cached codec
- Updated tests to ensure category behaviour works properly
- Updated docs

