### PR TITLE
feat: add property for whether categories should show in menu

### DIFF
--- a/docs/dev/commerce-codec.md
+++ b/docs/dev/commerce-codec.md
@@ -71,6 +71,7 @@ Represents a category of products, with identifiers, an image, tree structure (p
 
 -   Category slug is used to fetch products by category. It is intended to be a user readable ID that you might find in a URL.
 -   `products` does not need to be hydrated unless the user specifically requests the category.
+-   `showInMenu` is if the commerce vendor has a visible flag for a category. If not then default to true.
 
 ```ts
 /**
@@ -84,6 +85,7 @@ export type Category = CommerceObject & {
     image?: Image
     children: Category[]
     products: Product[]
+    showInMenu: boolean
 }
 ```
 

--- a/src/codec/codecs/commerce/bigcommerce-cors/bigcommerce.test.ts
+++ b/src/codec/codecs/commerce/bigcommerce-cors/bigcommerce.test.ts
@@ -108,7 +108,8 @@ describe('bigcommerce cors integration', function () {
 				slug: 'shop-all',
 				id: '23',
 				children: [],
-				products: []
+				products: [],
+				showInMenu: true,
 			}
 		})
 
@@ -277,7 +278,8 @@ describe('bigcommerce cors integration', function () {
 			slug: 'shop-all',
 			id: '23',
 			children: [],
-			products: exampleProducts(15)
+			products: exampleProducts(15),
+			showInMenu: true,
 		})
 
 		expect(requests).toEqual([

--- a/src/codec/codecs/commerce/bigcommerce-cors/mappers.ts
+++ b/src/codec/codecs/commerce/bigcommerce-cors/mappers.ts
@@ -16,7 +16,8 @@ export const mapCategory = (category: BigCommerceCorsCategoryTreeItem): Category
 		name: category.name,
 		slug: slugify(category.name, { lower: true }),
 		children: category.children.map(mapCategory),
-		products: []
+		products: [],
+		showInMenu: true
 	}
 }
 

--- a/src/codec/codecs/commerce/bigcommerce-cors/test/results.ts
+++ b/src/codec/codecs/commerce/bigcommerce-cors/test/results.ts
@@ -5,7 +5,8 @@ export const exampleCategoryTree = [
 		name: 'Shop All',
 		slug: 'shop-all',
 		children: [],
-		products: []
+		products: [],
+		showInMenu: true
 	},
 	{
 		id: '18',
@@ -17,7 +18,8 @@ export const exampleCategoryTree = [
 				name: 'Bath Utilities',
 				slug: 'bath-utilities',
 				children: [],
-				products: []
+				products: [],
+				showInMenu: true
 			},
 			{
 				id: '25',
@@ -29,41 +31,48 @@ export const exampleCategoryTree = [
 						name: 'Electric',
 						slug: 'electric',
 						children: [],
-						products: []
+						products: [],
+						showInMenu: true
 					}
 				],
-				products: []
+				products: [],
+				showInMenu: true
 			}
 		],
-		products: []
+		products: [],
+		showInMenu: true
 	},
 	{
 		id: '19',
 		name: 'Garden',
 		slug: 'garden',
 		children: [],
-		products: []
+		products: [],
+		showInMenu: true
 	},
 	{
 		id: '21',
 		name: 'Kitchen',
 		slug: 'kitchen',
 		children: [],
-		products: []
+		products: [],
+		showInMenu: true
 	},
 	{
 		id: '20',
 		name: 'Publications',
 		slug: 'publications',
 		children: [],
-		products: []
+		products: [],
+		showInMenu: true
 	},
 	{
 		id: '22',
 		name: 'Utility',
 		slug: 'utility',
 		children: [],
-		products: []
+		products: [],
+		showInMenu: true
 	}
 ]
 

--- a/src/codec/codecs/commerce/bigcommerce/bigcommerce.test.ts
+++ b/src/codec/codecs/commerce/bigcommerce/bigcommerce.test.ts
@@ -162,6 +162,7 @@ describe('bigcommerce integration', function () {
 				id: '1',
 				name: 'Category',
 				slug: 'category',
+				showInMenu: true,
 			}
 		})
 		expect(requests).toEqual([
@@ -291,6 +292,7 @@ describe('bigcommerce integration', function () {
 			id: '1',
 			name: 'Men',
 			slug: 'men',
+			showInMenu: true,
 		})
 	})
 

--- a/src/codec/codecs/commerce/bigcommerce/mappers.ts
+++ b/src/codec/codecs/commerce/bigcommerce/mappers.ts
@@ -15,7 +15,8 @@ export const mapCategory = (category: BigCommerceCategory): Category => {
 		name: category.name,
 		slug: slugify(category.name, { lower: true }),
 		children: category.children.map(mapCategory),
-		products: []
+		products: [],
+		showInMenu: category.is_visible
 	}
 }
 

--- a/src/codec/codecs/commerce/bigcommerce/test/results.ts
+++ b/src/codec/codecs/commerce/bigcommerce/test/results.ts
@@ -14,48 +14,55 @@ export const exampleCategoryTree = [
 		slug: 'men',
 		children: [],
 		products: [],
+		showInMenu: true
 	},
 	{
 		id: '23',
 		name: 'Browse all',
 		slug: 'browse-all',
 		children: [],
-		products: []
+		products: [],
+		showInMenu: true
 	},
 	{
 		id: '18',
 		name: 'Bathroom',
 		slug: 'bathroom',
 		children: [],
-		products: []
+		products: [],
+		showInMenu: true
 	},
 	{
 		id: '19',
 		name: 'Garden',
 		slug: 'garden',
 		children: [],
-		products: []
+		products: [],
+		showInMenu: true
 	},
 	{
 		id: '21',
 		name: 'Kitchen',
 		slug: 'kitchen',
 		children: [],
-		products: []
+		products: [],
+		showInMenu: true
 	},
 	{
 		id: '20',
 		name: 'Publications',
 		slug: 'publications',
 		children: [],
-		products: []
+		products: [],
+		showInMenu: true
 	},
 	{
 		id: '22',
 		name: 'Maintenance',
 		slug: 'maintenance',
 		children: [],
-		products: []
+		products: [],
+		showInMenu: true
 	}
 ]
 

--- a/src/codec/codecs/commerce/commercetools/commercetools.test.ts
+++ b/src/codec/codecs/commerce/commercetools/commercetools.test.ts
@@ -121,6 +121,7 @@ describe('commercetools integration', function() {
 			id: 'men-id',
 			name: 'Men',
 			slug: 'men',
+			showInMenu: true,
 		}})
 
 		expect(requests).toEqual([
@@ -262,12 +263,14 @@ describe('commercetools integration', function() {
 					name: 'Men\'s Accessories',
 					products: [],
 					slug: 'mens-accessories',
+					showInMenu: true,
 				}
 			],
 			products: Array.from({length: 30}).map((_, index) => exampleProduct('Hit' + index)),
 			id: 'men-id',
 			name: 'Men',
 			slug: 'root-men',
+			showInMenu: true,
 		})
 	})
 

--- a/src/codec/codecs/commerce/commercetools/index.ts
+++ b/src/codec/codecs/commerce/commercetools/index.ts
@@ -128,7 +128,8 @@ const mapCategory = (category: CTCategory, categories: CTCategory[], args: Commo
 		name: localize(category.name, args),
 		slug: localize(category.slug, args),
 		children: categories.filter(cat => cat.parent?.id === category.id).map(cat => mapCategory(cat, categories, args)),
-		products: []
+		products: [],
+		showInMenu: true
 	}
 }
 

--- a/src/codec/codecs/commerce/commercetools/test/results.ts
+++ b/src/codec/codecs/commerce/commercetools/test/results.ts
@@ -42,12 +42,14 @@ export const exampleCategoryTree = [
 				name: 'Men\'s Accessories',
 				products: [],
 				slug: 'mens-accessories',
+				showInMenu: true,
 			}
 		],
 		id: 'men-id',
 		name: 'Men',
 		products: [],
 		slug: 'root-men',
+		showInMenu: true,
 	}
 ]
 
@@ -60,12 +62,14 @@ export const exampleCategoryTreeEs = [
 				name: 'Hombre Accessories',
 				products: [],
 				slug: 'mens-accessories',
+				showInMenu: true,
 			}
 		],
 		id: 'men-id',
 		name: 'Hombre',
 		products: [],
 		slug: 'root-men',
+		showInMenu: true,
 	}
 ]
 

--- a/src/codec/codecs/commerce/rest/index.ts
+++ b/src/codec/codecs/commerce/rest/index.ts
@@ -93,6 +93,16 @@ export class RestCommerceCodec extends CommerceCodec {
 	customerGroups: CustomerGroup[]
 	translations: Dictionary<Dictionary<string>>
 
+	updateCategoriesVersion(categories: Category[]): void {
+		for (const category of categories) {
+			if (!('showInMenu' in category)) {
+				(category as Category).showInMenu = true
+			}
+
+			this.updateCategoriesVersion(category.children)
+		}
+	}
+
 	/**
 	 * @inheritdoc
 	 */
@@ -102,6 +112,8 @@ export class RestCommerceCodec extends CommerceCodec {
 		this.customerGroups = await fetchFromURL(this.config.customerGroupURL, [])
 		this.translations = await fetchFromURL(this.config.translationsURL, {})
 		this.categoryTree = this.categories.filter(cat => !cat.parent)
+		
+		this.updateCategoriesVersion(this.categories)
 	}
 
 	/**

--- a/src/codec/codecs/commerce/rest/test/responses.ts
+++ b/src/codec/codecs/commerce/rest/test/responses.ts
@@ -10,6 +10,7 @@ export const rootCategory: Category = {
 	},
 	children: [],
 	products: [],
+	showInMenu: false,
 }
 
 export const childCategories: Category[] = [{
@@ -22,6 +23,7 @@ export const childCategories: Category[] = [{
 	},
 	children: [],
 	products: [],
+	showInMenu: true,
 },
 {
 	id: 'child2',
@@ -33,6 +35,7 @@ export const childCategories: Category[] = [{
 	},
 	children: [],
 	products: [],
+	showInMenu: true,
 }]
 
 rootCategory.children = childCategories

--- a/src/codec/codecs/commerce/sfcc/index.ts
+++ b/src/codec/codecs/commerce/sfcc/index.ts
@@ -91,7 +91,8 @@ const mapCategory = (category: SFCCCategory): Category => {
 		slug: category.id,
 		name: category.name,
 		children: category.categories?.map(mapCategory) || [],
-		products: []
+		products: [],
+		showInMenu: category.c_showInMenu
 	}
 }
 

--- a/src/codec/codecs/commerce/sfcc/sfcc.test.ts
+++ b/src/codec/codecs/commerce/sfcc/sfcc.test.ts
@@ -123,6 +123,7 @@ describe('sfcc integration', function() {
 			id: 'newarrivals-womens',
 			name: 'Womens',
 			slug: 'newarrivals-womens',
+			showInMenu: true
 		}})
 
 		expect(requests).toEqual([
@@ -263,6 +264,7 @@ describe('sfcc integration', function() {
 			id: 'newarrivals-womens',
 			name: 'Womens',
 			slug: 'newarrivals-womens',
+			showInMenu: true,
 		})
 	})
 

--- a/src/codec/codecs/commerce/sfcc/test/results.ts
+++ b/src/codec/codecs/commerce/sfcc/test/results.ts
@@ -74,6 +74,7 @@ export const exampleCategoryTree: Category[] = [
 		name: 'Content',
 		products: [],
 		slug: 'content-link',
+		showInMenu: true,
 	},
 	{
 		children: [
@@ -83,6 +84,7 @@ export const exampleCategoryTree: Category[] = [
 				name: 'Womens',
 				products: [],
 				slug: 'newarrivals-womens',
+				showInMenu: true,
 			},
 			{
 				children: [],
@@ -90,12 +92,14 @@ export const exampleCategoryTree: Category[] = [
 				name: 'Mens',
 				products: [],
 				slug: 'newarrivals-mens',
+				showInMenu: true,
 			},
 		],
 		id: 'newarrivals',
 		name: 'New Arrivals',
 		products: [],
 		slug: 'newarrivals',
+		showInMenu: true,
 	},
 ]
 

--- a/src/codec/codecs/commerce/shopify/mappers.ts
+++ b/src/codec/codecs/commerce/shopify/mappers.ts
@@ -51,7 +51,8 @@ export const mapCategory = (collection: ShopifyCollection): Category => {
 		name: collection.title,
 		image: collection.image,
 		children: [],
-		products: []
+		products: [],
+		showInMenu: true
 	}
 }
 

--- a/src/codec/codecs/commerce/shopify/shopify.test.ts
+++ b/src/codec/codecs/commerce/shopify/shopify.test.ts
@@ -111,7 +111,8 @@ describe('shopify integration', function () {
 				name: 'Hydrogen',
 				image: null,
 				children: [],
-				products: []
+				products: [],
+				showInMenu: true,
 			}
 		})
 
@@ -164,7 +165,8 @@ describe('shopify integration', function () {
 				name: 'Hydrogen',
 				image: null,
 				children: [],
-				products: []
+				products: [],
+				showInMenu: true,
 			},
 
 			pageNum: 1,

--- a/src/codec/codecs/commerce/shopify/test/results.ts
+++ b/src/codec/codecs/commerce/shopify/test/results.ts
@@ -25,6 +25,7 @@ export const exampleCategoryTree = [
 		image: null,
 		children: [],
 		products: [],
+		showInMenu: true,
 	},
 	{
 		id: '439038804256',
@@ -33,6 +34,7 @@ export const exampleCategoryTree = [
 		image: null,
 		children: [],
 		products: [],
+		showInMenu: true,
 	},
 	{
 		id: '439038837024',
@@ -41,6 +43,7 @@ export const exampleCategoryTree = [
 		image: null,
 		children: [],
 		products: [],
+		showInMenu: true,
 	},
 ]
 
@@ -56,6 +59,7 @@ export const exampleProduct = (id: string) => ({
 			image: null,
 			children: [],
 			products: [],
+			showInMenu: true,
 		},
 	],
 	variants: [
@@ -99,6 +103,7 @@ export const exampleCategoryProducts = {
 					image: null,
 					children: [],
 					products: [],
+					showInMenu: true,
 				},
 				{
 					id: '439038837024',
@@ -107,6 +112,7 @@ export const exampleCategoryProducts = {
 					image: null,
 					children: [],
 					products: [],
+					showInMenu: true,
 				},
 			],
 			variants: [
@@ -142,6 +148,7 @@ export const exampleCategoryProducts = {
 					image: null,
 					children: [],
 					products: [],
+					showInMenu: true,
 				},
 			],
 			variants: [
@@ -179,6 +186,7 @@ export const exampleCategoryProducts = {
 					image: null,
 					children: [],
 					products: [],
+					showInMenu: true,
 				},
 				{
 					id: '439038837024',
@@ -187,6 +195,7 @@ export const exampleCategoryProducts = {
 					image: null,
 					children: [],
 					products: [],
+					showInMenu: true,
 				},
 			],
 			variants: [
@@ -213,6 +222,7 @@ export const exampleCategoryProducts = {
 				'Snowboard that might explode if you bring a match to it.',
 		},
 	],
+	showInMenu: true,
 }
 
 const snowboardResult = () => ({

--- a/src/codec/codecs/pagination.ts
+++ b/src/codec/codecs/pagination.ts
@@ -85,8 +85,8 @@ export function getPageByQuery(offsetQuery: string, countQuery: string, totalPro
 			}
 
 			return {
-				data: resultPropMap(response),
-				total: totalPropMap(response)
+				data: resultPropMap(response) ?? [],
+				total: totalPropMap(response) ?? 0
 			}
 		}
 }
@@ -119,8 +119,8 @@ export function getPageByQueryAxios(offsetQuery: string, countQuery: string, tot
 			logResponse('get', newUrl, response.data)
 
 			return {
-				data: resultPropMap(response.data),
-				total: totalPropMap(response.data)
+				data: resultPropMap(response.data) ?? [],
+				total: totalPropMap(response.data) ?? 0
 			}
 		}
 }

--- a/src/common/api.ts
+++ b/src/common/api.ts
@@ -24,5 +24,4 @@ export type CommerceAPI = API & {
 	getCustomerGroups: (args: CommonArgs) => Promise<CustomerGroup[]>
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	getRawProducts: (args: GetProductsArgs) => Promise<any[]>
-	vendor: () => Promise<string>
 }

--- a/src/common/api.ts
+++ b/src/common/api.ts
@@ -24,4 +24,5 @@ export type CommerceAPI = API & {
 	getCustomerGroups: (args: CommonArgs) => Promise<CustomerGroup[]>
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	getRawProducts: (args: GetProductsArgs) => Promise<any[]>
+	vendor: () => Promise<string>
 }

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -61,6 +61,7 @@ export type Category = CommerceObject & {
 	image?: Image
 	children: Category[]
 	products: Product[]
+	showInMenu: boolean
 }
 
 /**


### PR DESCRIPTION
New Features:
- Categories now include a "showInMenu" boolean, which is set as true if the category is flagged to show in a mega menu. This defaults to true when unavailable.

Fixes:
- Add a failsafe if a pagination request returns undefined or null. Typically caused an error when paginating an empty category with SFCC.